### PR TITLE
Removing makeDirective/makeSelector boilerplate from app.js

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -1,9 +1,10 @@
 import angular from 'angular';
 import MainApp from './components/MainApp';
 import GameCard from './components/GameCard';
-import {makeSelector, makeDirective} from './utils';
+import {register} from './utils';
 
-export default angular
-  .module('app', [])
-  .directive(makeSelector(MainApp), makeDirective(MainApp))
-  .directive(makeSelector(GameCard), makeDirective(GameCard));
+const app = angular.module('app', []);
+
+export default register(app, {
+  components: [ MainApp, GameCard ],
+});

--- a/source/utils/index.js
+++ b/source/utils/index.js
@@ -41,3 +41,9 @@ export function makeSelector(component) {
     (g) => g[1].toUpperCase()
   );
 }
+
+export function register(app, {components}) {
+  return components.reduce((module, component) => module.directive(
+    makeSelector(component), makeDirective(component)
+  ), app);
+}


### PR DESCRIPTION
Before we were calling `makeDirective` and `makeSelector` in `app.js`. This seemed like needless boilerplate, so I refactored out the functionality into a `register` utility function. Right now, all it does is register the components with the angular module. In the future, I can imagine it handling the services,  config, constants, like the following:

``` JavaScript
import angular from 'angular';
import MainApp from './components/MainApp';
import GameCard from './components/GameCard';
import AuthService from './services/AuthService';
import router from './router.config';
import API_KEYS from './constants/api-keys';
import {register} from './utils';

const app = angular.module('app', []);

export default register(app, {
  components: [ MainApp, GameCard ],
  services: [ AuthService ],
  constants: [ API_KEYS ],
  config: [ router ]
});
```

Thoughts? The benefit of the new utility function is that `app.js` will be substantially less bloated. In regular angular, a single line is required to register a dependency. For example:

``` JavaScript
module
  .service('QWERTY', QUERTY)
  .factory('HORSE', HORSE)
  .constants('GOOSE', GOOSE)
// ...
```

This above wastes a lot of space. In the `register` function call, however, we can list all dependencies of the same type on a single line. 
